### PR TITLE
API-20 Containarization of API and Database

### DIFF
--- a/BackEndAPI/appsettings.json
+++ b/BackEndAPI/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Database" : "Server=localhost;Port=5432;Database=postgres;User Id=postgres;Password=tina;"
+    "DefaultConnection" : "Server=localhost;Port=5432;Database=postgres;User Id=postgres;Password=tina;"
   }
 }

--- a/DataAccess/AppContext.cs
+++ b/DataAccess/AppContext.cs
@@ -6,25 +6,10 @@ namespace DataAccess;
 
 public class AppContext : DbContext
 {
-    // private readonly IConfiguration configuration;
-    // public AppContext(IConfiguration configuration)
-    // {
-    //     this.configuration = configuration;
-    // }
-
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        optionsBuilder.UseNpgsql("Server=localhost;Port=5432;Database=postgres;User Id=postgres;Password=tina;");
-    }
-
     public DbSet<Plant> Plants { get; set; }
     public DbSet<PlantPreset> Presets { get; set; }
-
-    // I am not sure if we need this 
     
-    // protected override void OnModelCreating(ModelBuilder modelBuilder)
-    // {
-    //     modelBuilder.Entity<PlantPreset>().HasKey(preset => preset.PresetId);
-    //     modelBuilder.Entity<Plant>().HasKey(plant => plant.PlantId);
-    // }
+    public AppContext(DbContextOptions<AppContext> options) : base(options)
+    {
+    }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build-env
+#This image is used for building the application
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
 WORKDIR /app
-
 COPY . ./
 RUN dotnet restore
 RUN dotnet publish -c Release -o out
 
+#This image is used to run the application
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
 EXPOSE 5000
 ENV ASPNETCORE_URLS=http://+:5000
 COPY --from=build-env /app/out .
-ENTRYPOINT ["dotnet", "BackEndAPI.dll"]
+#Adding postgressql-client and a custom entrypoint, where the docker waits until the database is finished loading
+#Afterwards proceeds with running the API
+RUN apk add --no-cache postgresql-client
+COPY entrypoint.sh ./
+RUN chmod +x ./entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Scripts/clear_docker_build.py
+++ b/Scripts/clear_docker_build.py
@@ -1,0 +1,34 @@
+import sys
+import subprocess
+import argparse
+import re
+
+def run_compose_down():
+    subprocess.run(["docker", "compose", "down", "-v"])
+def run_build_api(new_image_name):
+    subprocess.run(["docker", "build", "-t", new_image_name, ".."])
+def rename_image_name_in_compose_file(new_image_name):
+    composePath = '../docker-compose.yml';
+    with open(composePath, 'r') as file:
+        content = file.read()
+        
+    content = re.sub(r'image: "plantapi"', f'image: "{new_image_name}"', content)
+    
+    with open(composePath, 'w') as file:
+        file.write(content)
+def run_compose_up():
+    subprocess.run(["docker", "compose","-f", "../docker-compose.yml", "up"]).wait()
+
+def main():
+    parser = argparse.ArgumentParser(description="clean build docker")
+    parser.add_argument("image_name", type=str, help="The new API image name")
+    args = parser.parse_args()
+    
+    run_compose_down()
+    run_build_api(args.image_name)
+    rename_image_name_in_compose_file(args.image_name)
+    run_compose_up()
+   
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/new_migration.py
+++ b/Scripts/new_migration.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from datetime import datetime
+
+def is_ef_installed():
+    try:
+        subprocess.run(["dotnet", "ef"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except FileNotFoundError:
+        return False
+
+def install_ef():
+    subprocess.run(["dotnet", "tool", "install", "--global", "dotnet-ef"])
+
+def run_migration(migration_name):
+    subprocess.run([
+        "dotnet", "ef", "migrations", "add", migration_name,
+        "--project", "../DataAccess/DataAccess.csproj",
+        "--startup-project", "../BackEndAPI/BackEndAPI.csproj"
+    ])
+
+def main():
+    if len(sys.argv) < 2:
+        migration_name = "Migration_" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    else:
+        migration_name = sys.argv[1]
+
+    if not is_ef_installed():
+        print("Entity Framework CLI is not installed. Installing now...")
+        install_ef()
+
+    run_migration(migration_name)
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+
+services:
+  plantapi:
+    image: "plantapi"
+    ports:
+      - "5000:5000"
+    environment:
+      - ConnectionStrings__DefaultConnection=Server=db;Port=5432;Database=plantdb;UserId=admin;Password=root;
+    depends_on:
+      - db
+  db:
+    image: postgres:latest
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=plantdb
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=root
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#Waiting for the db to get initialized so that migration of data tables is possible in runtime
+while ! pg_isready -h db -p 5432 -q -U admin; do
+  echo "Waiting for PostgreSQL to start..."
+  sleep 2
+done
+
+echo "PostgreSQL finished loading. Starting API..."
+dotnet BackEndAPI.dll


### PR DESCRIPTION
- creating docker-compose file which tells the docker to run our created image of API and also a new image of database (with a volume so that the data persist across multiple sessions)
- creating entrypoint.sh which is awaiting the database initialization to be finished before starting up API(due to the migration happening on the runtime)
- editing the docker file to install postgresql-client and run the entrypoint.sh as the entrypoint of our containarized application
- changing the structure of AppContext class to use connection string from appsettings.json
- in Program.cs enabling to show swagger even when it was build to production (for now keep it like that, we will remove it eventually)
- in Program.cs adding options to the DbContext to use connection string defined in either appsettings.json(when running locally) or environment variables (while running in docker)
- creating clear_docker_build python script which provides an easy way to clean build the solution and run it in docker
- creating new_migraition script which provides an easy way to create a new migrations